### PR TITLE
Following symlinks disabled to avoid path traversal attacks

### DIFF
--- a/examples/server/index.js
+++ b/examples/server/index.js
@@ -16,7 +16,8 @@ var spec = {
   cwd: __dirname,
   errorPage: __dirname + '/error.html',
   compression: true,
-  debug: true
+  debug: true,
+  allowSymlinks: false
 };
 
 var app = superstatic(spec);

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -12,11 +12,18 @@ var pathjoin = require('join-path');
 var RSVP = require('rsvp');
 var _ = require('lodash');
 
-var statPromise = RSVP.denodeify(fs.stat);
+var statPromise = RSVP.denodeify(fs.lstat);
 var multiStat = function(paths) {
   var pathname = paths.shift();
   return statPromise(pathname).then(function(stat) {
     stat.path = pathname;
+
+    // Disable following symlinks to avoid path traversal attacks
+    if(stat.isSymbolicLink()) {
+      console.log('Symlinks disabled to avoid path traversal attacks');
+      return RSVP.reject({code: 'EINVAL'});
+    }
+
     return stat;
   }, function(err) {
     if (paths.length) {

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -11,6 +11,7 @@ var fs = require('fs');
 var pathjoin = require('join-path');
 var RSVP = require('rsvp');
 var _ = require('lodash');
+var allowSymlinks = false;
 
 var statPromise = RSVP.denodeify(fs.lstat);
 var multiStat = function(paths) {
@@ -18,10 +19,14 @@ var multiStat = function(paths) {
   return statPromise(pathname).then(function(stat) {
     stat.path = pathname;
 
-    // Disable following symlinks to avoid path traversal attacks
-    if(stat.isSymbolicLink()) {
-      console.log('Symlinks disabled to avoid path traversal attacks');
-      return RSVP.reject({code: 'EINVAL'});
+    if (!allowSymlinks) {
+
+      // Disable following symlinks to avoid path traversal attacks
+      if(stat.isSymbolicLink()) {
+        console.log('Symlinks disabled to avoid path traversal attacks, you can enable symlinks by seting "allowSymlinks: true" in specs while creating superstatic, be warned that can lead to path traversal attacks');
+        return RSVP.reject({code: 'EINVAL'});
+      }
+
     }
 
     return stat;
@@ -35,6 +40,7 @@ var multiStat = function(paths) {
 
 module.exports = function(options) {
   var etagCache = {};
+  allowSymlinks = options.allowSymlinks;
   var cwd = options.cwd || process.cwd();
   var publicPaths = options.public || ['.'];
   if (!_.isArray(publicPaths)) {

--- a/lib/superstatic.js
+++ b/lib/superstatic.js
@@ -39,6 +39,7 @@ var superstatic = function(spec) {
   // Load data
   var config = spec.config = loadConfigFile(spec.config);
   config.errorPage = config.errorPage || '/404.html';
+  config.allowSymlinks = spec.allowSymlinks || false;
 
   // Set up provider
   var provider = spec.provider ? promiseback(spec.provider, 2) : fsProvider(_.extend({


### PR DESCRIPTION
### 📊 Metadata *

Fix for path traversal attacks reported in huntr

#### Bounty URL: 

https://www.huntr.dev/bounties/1-npm-superstatic/

### ⚙️ Description *

Avoid path traversal attacks by disabling showing symlinks, previous behaviour can be achived by setting "allowSymlinks: true" in specs, defaults to false

### 💻 Technical Description *

using fs.lstat instead of fs.stat and in testing for symlink by using isSymbolicLink(), in case its symbolic link we return file error and log into console.

### 🐛 Proof of Concept (PoC) *

By creating  symbolic link inside of example server app/poc.txt pointing to file that shouldn't be reachable by server, 

![Captura de pantalla de 2020-08-21 13-22-29](https://user-images.githubusercontent.com/7505980/90881164-58b28600-e3b2-11ea-8274-99827126ef02.png)

The content of the file can be accessed by poc.txt:

![Captura de pantalla de 2020-08-21 13-21-22](https://user-images.githubusercontent.com/7505980/90881124-48021000-e3b2-11ea-9317-0a59aa1c3b96.png)


### 🔥 Proof of Fix (PoF) *

After fix server will return: "Nothing here. Move on."

![Captura de pantalla de 2020-08-21 13-23-01](https://user-images.githubusercontent.com/7505980/90881208-6d8f1980-e3b2-11ea-89c8-b92f96ffc5fe.png)

and log: "Symlinks disabled to avoid path traversal attacks"

![Captura de pantalla de 2020-08-21 13-23-06](https://user-images.githubusercontent.com/7505980/90881216-72ec6400-e3b2-11ea-9459-66bea5e65cb3.png)

### 👍 User Acceptance Testing (UAT)

Example server continue working as normal

![Captura de pantalla de 2020-08-21 13-21-09](https://user-images.githubusercontent.com/7505980/90881098-3c164e00-e3b2-11ea-96d7-e355729a026e.png)
