### PR TITLE
[FIX] Path traversal through Symlink files

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Instantiates a Connect server, setting up Superstatic middleware, port, host, de
   * `errorPage` - A file path to a custom error page. Defaults to [Superstatic's error page](https://github.com/firebase/superstatic/blob/master/lib/assets/not_found.html).
   * `debug` - A boolean value that tells Superstatic to show or hide network logging in the console. Defaults to `false`.
   * `compression` - A boolean value that tells Superstatic to serve gzip/deflate compressed responses based on the request Accept-Encoding header and the response Content-Type header. Defaults to `false`.
+  * `symlink` - A boolean value that tells Superstatic to resolve and show also `symlink` files. Defaults to `false` to prevent `path traversal attacks`.
   * `gzip` **[DEPRECATED]** - A boolean value which is now equivalent in behavior to `compression`. Defaults to `false`.
 
 ## Providers

--- a/lib/cli/flags.js
+++ b/lib/cli/flags.js
@@ -31,6 +31,12 @@ module.exports = function(cli, options, ready) {
       done();
     });
 
+  cli.flag('--symlink')
+    .handler(function(shouldEnableSymlink, done) {
+      cli.set('symlink', shouldEnableSymlink);
+      done();
+    });
+
   cli.flag('--gzip')
     .handler(function(shouldCompress, done) {
       cli.set('compression', shouldCompress);

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -16,6 +16,7 @@ var CONFIG_FILENAME = ['superstatic.json', 'firebase.json'];
 var ENV_FILENAME = '.env.json';
 var DEBUG = false;
 var LIVE = false;
+var SYMLINK = false;
 
 var env;
 try {
@@ -35,6 +36,7 @@ module.exports = function() {
   cli.set('env', env);
   cli.set('debug', DEBUG);
   cli.set('live', LIVE);
+  cli.set('symlink', SYMLINK);
 
   // If no commands matched, the user probably
   // wants to run a server

--- a/lib/cli/server.js
+++ b/lib/cli/server.js
@@ -20,7 +20,7 @@ module.exports = function(cli, imports, ready) {
       var compression = cli.get('compression');
       var env = cli.get('env');
       var live = cli.get('live');
-
+      var symlink = cli.get('symlink');
       var workingDirectory = data[0];
 
       var options = {
@@ -30,7 +30,8 @@ module.exports = function(cli, imports, ready) {
         compression: compression,
         debug: debug,
         env: env,
-        live: live
+        live: live,
+        symlink: symlink
       };
 
       cli.set('options', options);

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -84,10 +84,10 @@ module.exports = function(options) {
     return multiStat(fullPathnames).then(function(stat) {
       result.modified = stat.mtime.getTime();
 
-       if (!symlink) {
-        // Symlinks removed by default
-        if(stat.isSymb) {
-          return RSVP.reject({code: 'EINVAL'});
+      if (!symlink) {
+       // Symlinks removed by default
+       if(stat.isSymb) {
+         return RSVP.reject({code: 'EINVAL'});
         }
 
       }

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -16,8 +16,8 @@ var statPromise = RSVP.denodeify(fs.lstat);
 var multiStat = function(paths) {
   var pathname = paths.shift();
   return statPromise(pathname).then(function(stat) {
-  	stat.isSymb = stat.isSymbolicLink();
-  	stat.path = pathname;
+    stat.isSymb = stat.isSymbolicLink();
+    stat.path = pathname;
     return stat;
   }, function(err) {
     if (paths.length) {

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -12,12 +12,20 @@ var pathjoin = require('join-path');
 var RSVP = require('rsvp');
 var _ = require('lodash');
 
-var statPromise = RSVP.denodeify(fs.stat);
+var statPromise = RSVP.denodeify(fs.lstat);
 var multiStat = function(paths) {
   var pathname = paths.shift();
   return statPromise(pathname).then(function(stat) {
+
+    if (stat.isSymbolicLink()) {
+      stat.isSymbolicLink = true;
+    } else {
+      stat.isSymbolicLink = false;
+    }
+
     stat.path = pathname;
     return stat;
+
   }, function(err) {
     if (paths.length) {
       return multiStat(paths);
@@ -30,6 +38,8 @@ module.exports = function(options) {
   var etagCache = {};
   var cwd = options.cwd || process.cwd();
   var publicPaths = options.public || ['.'];
+  var symlink = options.symlink;
+
   if (!_.isArray(publicPaths)) {
     publicPaths = [publicPaths];
   }
@@ -79,10 +89,17 @@ module.exports = function(options) {
     });
 
     return multiStat(fullPathnames).then(function(stat) {
-      foundPath = stat.path;
+
+      if(stat.isSymbolicLink && symlink === false)
+        foundPath = '/';
+      else if (stat.isSymbolicLink && symlink === true)
+        foundPath = stat.path;
+      else if ( (!stat.isSymbolicLink && symlink === true) || (!stat.isSymbolicLink && symlink === false) )
+        foundPath = stat.path;
+
       result.modified = stat.mtime.getTime();
       result.size = stat.size;
-      return _fetchEtag(stat.path, stat);
+      return _fetchEtag(foundPath, stat);
     }).then(function(etag) {
       result.etag = etag;
       result.stream = fs.createReadStream(foundPath);

--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -16,16 +16,9 @@ var statPromise = RSVP.denodeify(fs.lstat);
 var multiStat = function(paths) {
   var pathname = paths.shift();
   return statPromise(pathname).then(function(stat) {
-
-    if (stat.isSymbolicLink()) {
-      stat.isSymbolicLink = true;
-    } else {
-      stat.isSymbolicLink = false;
-    }
-
-    stat.path = pathname;
+  	stat.isSymb = stat.isSymbolicLink();
+  	stat.path = pathname;
     return stat;
-
   }, function(err) {
     if (paths.length) {
       return multiStat(paths);
@@ -89,17 +82,20 @@ module.exports = function(options) {
     });
 
     return multiStat(fullPathnames).then(function(stat) {
-
-      if(stat.isSymbolicLink && symlink === false)
-        foundPath = '/';
-      else if (stat.isSymbolicLink && symlink === true)
-        foundPath = stat.path;
-      else if ( (!stat.isSymbolicLink && symlink === true) || (!stat.isSymbolicLink && symlink === false) )
-        foundPath = stat.path;
-
       result.modified = stat.mtime.getTime();
+
+       if (!symlink) {
+        // Symlinks removed by default
+        if(stat.isSymb) {
+          return RSVP.reject({code: 'EINVAL'});
+        }
+
+      }
+
+      foundPath = stat.path;
+
       result.size = stat.size;
-      return _fetchEtag(foundPath, stat);
+      return _fetchEtag(stat.path, stat);
     }).then(function(etag) {
       result.etag = etag;
       result.stream = fs.createReadStream(foundPath);

--- a/lib/responder.js
+++ b/lib/responder.js
@@ -20,6 +20,7 @@ var Responder = function(req, res, options) {
   this.config = options.config || {};
   this.rewriters = options.rewriters || {};
   this.compressor = options.compressor;
+  this.symlink = options.symlink;
 };
 
 Responder.prototype.isNotModified = function(stats) {

--- a/lib/superstatic.js
+++ b/lib/superstatic.js
@@ -42,7 +42,8 @@ var superstatic = function(spec) {
 
   // Set up provider
   var provider = spec.provider ? promiseback(spec.provider, 2) : fsProvider(_.extend({
-    cwd: cwd // default current working directory
+    cwd: cwd, // default current working directory
+    symlink: spec.symlink // symlink
   }, config));
 
   // Select compression middleware
@@ -55,13 +56,15 @@ var superstatic = function(spec) {
     compressor = null;
   }
 
+
   // Setup helpers
   router.use(function(req, res, next) {
     res.superstatic = new Responder(req, res, {
       provider: provider,
       config: config,
       compressor: compressor,
-      rewriters: spec.rewriters
+      rewriters: spec.rewriters,
+      symlink: spec.symlink
     });
 
     next();


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-superstatic

### ⚙️ Description *

The `superstatic` server was vulnerable against a `path traversal` issue which occurred because `symlink` files where showed, leading to `dangerous scenario` which could be exploitable.

### 💻 Technical Description *

In order to avoid the issue, I added the possibility to simply check if the `symlink` option flag has been set when starting the server. If `symlink` flag is passed when invoking the `superstatic` command, the symlinks are showed and fetched successfully, whereas when `symlink` flag is missed, it's showed a `404` error.

The added `flag` makes possible switching really simply between the 2 options, and I added a bit of doc in the `README` to be sure people aware of the options it-self and risks.

Finally, the `default` value of the `symlink` flag is `false` (security reason, shares the same concept of other webserver like `Nginx`) and if devs are using the `lib version`, it's necessary just switching the `default` value to `true` in case they want to serve also `symlink` files.

### 🐛 Proof of Concept (PoC) *

1. Install 
2. Go on the `bin` dir
3. `./server`
4. Create a `symlink` like `ln -s /etc/passwd test`
5. Go on http://localhost:3474/test
6. Content of `/etc/passwd` showed

![Screenshot from 2020-08-20 15-01-04](https://user-images.githubusercontent.com/33063403/90940834-8201ff00-e410-11ea-9bdc-cf34868323c6.png)

### 🔥 Proof of Fix (PoF) *

Same steps with fixed version

**Using the `symlink` flag:**
![Screenshot from 2020-08-22 00-44-07](https://user-images.githubusercontent.com/33063403/90940926-c7263100-e410-11ea-8885-4e2257577284.png)

**Without `symlink` flag:**
![Screenshot from 2020-08-22 00-44-19](https://user-images.githubusercontent.com/33063403/90940932-cab9b800-e410-11ea-92fa-348490f0dbf7.png)

### 👍 User Acceptance Testing (UAT)

Seems all OK :+1: 