### PR TITLE
Fixed path traversal vulnerability when symlinking directories

### DIFF
--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -27,6 +27,20 @@ var multiStat = function(paths) {
   });
 };
 
+var symlinkPath = function(requestedpath, fullpath) {
+  var dirs = requestedpath.split('/');
+  if( dirs.length < 2) return false;
+  var basepath = fullpath.replace(new RegExp(requestedpath+"$"),"");
+  var testpath = basepath;
+  for( var i = 1; i < dirs.length-1; i++ ){
+    testpath = pathjoin(testpath, dirs[i]);
+    var stat = fs.lstatSync(testpath);
+    if( stat.isSymbolicLink() ){
+      return true;
+    }
+  }
+};
+
 module.exports = function(options) {
   var etagCache = {};
   var cwd = options.cwd || process.cwd();
@@ -85,9 +99,13 @@ module.exports = function(options) {
       result.modified = stat.mtime.getTime();
 
       if (!symlink) {
-       // Symlinks removed by default
-       if(stat.isSymb) {
-         return RSVP.reject({code: 'EINVAL'});
+        // Symlinks removed by default
+        if(stat.isSymb) {
+          return RSVP.reject({code: 'EINVAL'});
+        }
+        // If file is not symlink verify its not accessed by symlinked directory
+        if(symlinkPath(pathname, stat.path)) {
+          return RSVP.reject({code: 'EINVAL'});
         }
 
       }


### PR DESCRIPTION
### 📊 Metadata *

Creating a symlink to a directory could allow acces to system files

#### Bounty URL: https://www.huntr.dev/bounties/2-npm-superstatic/

### ⚙️ Description *

Path is tested for symlinked directories, in case it is request is denied

### 💻 Technical Description *

If symlink filter is enabled and file is not symlink every directory in the path, starting from base directory, is tested to be symlink, in positive case request is denied

### 🐛 Proof of Concept (PoC) *

1)Install the Superstatic module
$ npm install -g superstatic

2)Make a directory
$ mkdir test

3)Go to 'test' directory
$ cd test

4)create a symlink file to directory
ln -s /etc/ 'dirname'

![symlink](https://user-images.githubusercontent.com/7505980/92273434-074ae080-eef4-11ea-9150-c61730671c3b.png)

5)Run Superstatic module
Superstatic

6)Request the file within browser
http://localhost:3474/'dirname'/'regularfile'
http://localhost:3474/poc/passwd

7)Content of file is returned to browser

![Captura de pantalla de 2020-09-04 21-23-36](https://user-images.githubusercontent.com/7505980/92273940-fa7abc80-eef4-11ea-9d47-3aaa0743518b.png)


### 🔥 Proof of Fix (PoF) *

After fix error page is shown, any symlink in the path will be recognized

![longDir](https://user-images.githubusercontent.com/7505980/92273526-319c9e00-eef4-11ea-9591-61efab2b27b6.png)
![logDir](https://user-images.githubusercontent.com/7505980/92273530-32cdcb00-eef4-11ea-94ef-7a4304efa82d.png)
![vulFix](https://user-images.githubusercontent.com/7505980/92273532-33666180-eef4-11ea-8288-9018390b6fb5.png)


### 👍 User Acceptance Testing (UAT)

Original functionality unafected
![home](https://user-images.githubusercontent.com/7505980/92273541-36615200-eef4-11ea-9765-e187c42d2dde.png)

