### PR TITLE
Wrongly closed: Fixed path traversal vulnerability when symlinking directories

### DIFF
--- a/lib/providers/fs.js
+++ b/lib/providers/fs.js
@@ -27,6 +27,20 @@ var multiStat = function(paths) {
   });
 };
 
+var symlinkPath = function(requestedpath, fullpath) {
+  var dirs = requestedpath.split('/');
+  if( dirs.length < 2) return false;
+  var basepath = fullpath.replace(new RegExp(requestedpath+"$"),"");
+  var testpath = basepath;
+  for( var i = 1; i < dirs.length-1; i++ ){
+    testpath = pathjoin(testpath, dirs[i]);
+    var stat = fs.lstatSync(testpath);
+    if( stat.isSymbolicLink() ){
+      return true;
+    }
+  }
+};
+
 module.exports = function(options) {
   var etagCache = {};
   var cwd = options.cwd || process.cwd();
@@ -85,9 +99,13 @@ module.exports = function(options) {
       result.modified = stat.mtime.getTime();
 
       if (!symlink) {
-       // Symlinks removed by default
-       if(stat.isSymb) {
-         return RSVP.reject({code: 'EINVAL'});
+        // Symlinks removed by default
+        if(stat.isSymb) {
+          return RSVP.reject({code: 'EINVAL'});
+        }
+        // If file is not symlink verify its not accessed by symlinked directory
+        if(symlinkPath(pathname, stat.path)) {
+          return RSVP.reject({code: 'EINVAL'});
         }
 
       }


### PR DESCRIPTION
### 📊 Metadata *

Still valid as it fixes a Vulnerability after proposed fix #2

Creating a symlink to a directory could allow acces to system files, proposed fix handles symlinked files but not directories

#### Bounty URL: https://www.huntr.dev/bounties/2-npm-superstatic

### ⚙️ Description *

Path is tested for symlinked directories, in case it is request is denied

### 💻 Technical Description *

If symlink filter is enabled and file is not symlink every directory in the path, starting from base directory, is tested to be symlink, in positive case request is denied

### 🐛 Proof of Concept (PoC) *

1)Install the Superstatic module
$ npm install -g superstatic

2)Make a directory
$ mkdir test

3)Go to 'test' directory
$ cd test

4)create a symlink file to directory
ln -s /etc/ 'dirname'

5)Run Superstatic module
$ Superstatic

6)Request the file within browser
http://localhost:3474/'dirname'/'regularfile'
http://localhost:3474/poc/passwd

7)Content of file is returned to browser

### 🔥 Proof of Fix (PoF) *

After fix error page is shown

### 👍 User Acceptance Testing (UAT)

Original functionality unafected